### PR TITLE
Update graph_search.js end behavior instructions

### DIFF
--- a/project_pathplan/graph_search.js
+++ b/project_pathplan/graph_search.js
@@ -62,6 +62,9 @@ function iterateGraphSearch() {
     //   Return "succeeded" if the search succeeds on this iteration.
     //   Return "iterating" otherwise.
     //
+    //   When search is complete ("failed" or "succeeded") set the global variable 
+    //   search_iterate to false. 
+    //
     //   Provided support functions:
     //
     //   testCollision - returns whether a given configuration is in collision


### PR DESCRIPTION
Add a comment to instruct students to set search_iterate variable to false, a step that is missed by many students in multiple semesters and isn't yet specified in the instructions.